### PR TITLE
Fix typo in dart.py (def list)

### DIFF
--- a/dart.py
+++ b/dart.py
@@ -59,7 +59,7 @@ class OpenDartReader():
         if corp: # issues/6
             corp_code = self.find_corp_code(corp)
             if not corp_code:
-                raise ValueError('could not find "{}"'.format(code))
+                raise ValueError('could not find "{}"'.format(corp))
         else:
             corp_code = ''
         return dart_search.list(self.api_key, corp_code, start, end, kind, kind_detail, final)


### PR DESCRIPTION
dart.list() 메서드에 잘못된 기업 코드를 입력할 경우,

해당 에러 코드가 나오지 않고

